### PR TITLE
Add explict lodash dependence

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "singleQuote": true
   },
   "dependencies": {
+    "lodash": "^4.17.15",
     "react-color": "^2.17.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Patch to fix #6 where Yarn 2 will not allow lodash to be imported.