### PR TITLE
Fix crash when no 'controls' property is specified

### DIFF
--- a/src/components/ThemeControls.tsx
+++ b/src/components/ThemeControls.tsx
@@ -172,7 +172,12 @@ const ThemeControl = React.memo(
 
 ThemeControl.displayName = 'ThemeControl';
 
-const ThemeControls = ({ themeComponents, controls, config, onUpdate }) => {
+const ThemeControls = ({
+  themeComponents,
+  controls = {},
+  config,
+  onUpdate
+}) => {
   return (
     <>
       {themeComponents &&


### PR DESCRIPTION
This commit adds a small change that allows `controls` to be `undefined`.

Tested by removing the `controls` key from the example and seeing if everything still worked.

I suspect this bug is a major deterrent for users who just want to try out the vanilla version without much configuration. This commit should fix this.